### PR TITLE
feat: add reverse delegates

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,8 +22,6 @@ jobs:
 
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
-        with:
-          version: nightly
 
       - name: Show Forge version
         run: |

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "lib/forge-std"]
 	path = lib/forge-std
 	url = https://github.com/foundry-rs/forge-std
+[submodule "lib/openzeppelin-contracts"]
+	path = lib/openzeppelin-contracts
+	url = https://github.com/Openzeppelin/openzeppelin-contracts

--- a/src/DelegateRegistry.sol
+++ b/src/DelegateRegistry.sol
@@ -1,14 +1,21 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 pragma solidity ^0.8.29;
 
+import {EnumerableSet} from "@openzeppelin/contracts/utils/structs/EnumerableSet.sol";
+
 contract DelegateRegistry {
+    using EnumerableSet for EnumerableSet.AddressSet;
+
     // The first key is the delegator and the second key an id.
     // The value is the address of the delegate
     mapping(address delegator => mapping(bytes32 id => address delegate)) public delegation;
 
     // The first key is the delegate and the second key an id.
-    // The value is the number of delegations to this delegate for this id.
-    mapping(address delegate => mapping(bytes32 id => uint256 count)) public counter;
+    // The value is a set of delegators
+    // This is used to build up a reverse lookup of delegators for a specific delegate.
+    // The reverse lookup is not used in the contract itself, but it is useful for external
+    // applications to build up a list of delegators for a specific delegate.
+    mapping(address delegate => mapping(bytes32 id => EnumerableSet.AddressSet delegators)) private _reverseDelegation;
 
     // Using these events it is possible to process the events to build up reverse lookups.
     // The indices allow it to be very partial about how to build this lookup (e.g. only for a specific delegate).
@@ -27,10 +34,10 @@ contract DelegateRegistry {
 
         // Update delegation mapping
         delegation[msg.sender][id] = delegate;
-        counter[delegate][id] += 1;
+        _reverseDelegation[delegate][id].add(msg.sender);
 
         if (currentDelegate != address(0)) {
-            counter[currentDelegate][id] -= 1;
+            _reverseDelegation[currentDelegate][id].remove(msg.sender);
             emit ClearDelegate(msg.sender, id, currentDelegate);
         }
 
@@ -46,8 +53,57 @@ contract DelegateRegistry {
 
         // update delegation mapping
         delegation[msg.sender][id] = address(0);
-        counter[currentDelegate][id] -= 1;
+        _reverseDelegation[currentDelegate][id].remove(msg.sender);
 
         emit ClearDelegate(msg.sender, id, currentDelegate);
+    }
+
+    /**
+     * @notice Check if an address is a delegator for a specific delegate and ID
+     * @param delegate The delegate address
+     * @param id The delegation ID
+     * @param delegator The potential delegator to check
+     * @return bool True if the address has delegated to this delegate for this ID
+     */
+    function isDelegator(address delegate, bytes32 id, address delegator) external view returns (bool) {
+        return _reverseDelegation[delegate][id].contains(delegator);
+    }
+    
+    /**
+     * @notice Get the number of delegators for a specific delegate and ID
+     * @param delegate The delegate address
+     * @param id The delegation ID
+     * @return uint256 Number of delegators
+     */
+    function delegatorCount(address delegate, bytes32 id) external view returns (uint256) {
+        return _reverseDelegation[delegate][id].length();
+    }
+    
+    /**
+     * @notice Get a delegator by index for a specific delegate and ID
+     * @param delegate The delegate address
+     * @param id The delegation ID
+     * @param index The index in the delegators array
+     * @return address The delegator address at the specified index
+     */
+    function delegatorAt(address delegate, bytes32 id, uint256 index) external view returns (address) {
+        return _reverseDelegation[delegate][id].at(index);
+    }
+
+    /**
+     * @notice Get all delegators for a specific delegate and ID
+     * @param delegate The delegate address
+     * @param id The delegation ID
+     * @return address[] Array of delegator addresses
+     */
+    function getDelegators(address delegate, bytes32 id) external view returns (address[] memory) {
+        uint256 count = _reverseDelegation[delegate][id].length();
+        address[] memory result = new address[](count);
+        
+        for (uint256 i = 0; i < count; i++) {
+            result[i] = _reverseDelegation[delegate][id].at(i);
+        }
+        
+        return result;
     }
 }

--- a/src/DelegateRegistry.sol
+++ b/src/DelegateRegistry.sol
@@ -10,10 +10,9 @@ contract DelegateRegistry {
     // The value is the address of the delegate
     mapping(address delegator => mapping(bytes32 id => address delegate)) public delegation;
 
-    // The first key is the delegate and the second key an id.
-    // The value is the number of delegations to this delegate for this id.
+    // The value of delegations for this id.
     // This is used by Herodotus.
-    mapping(address delegate => mapping(bytes32 id => uint256 count)) public counter;
+    mapping(bytes32 id => uint256 count) public counter;
 
     // The first key is the delegate and the second key an id.
     // The value is a set of delegators
@@ -40,12 +39,13 @@ contract DelegateRegistry {
         // Update delegation mapping
         delegation[msg.sender][id] = delegate;
         _reverseDelegation[delegate][id].add(msg.sender);
-        counter[delegate][id] += 1;
 
         if (currentDelegate != address(0)) {
             _reverseDelegation[currentDelegate][id].remove(msg.sender);
-            counter[currentDelegate][id] -= 1;
             emit ClearDelegate(msg.sender, id, currentDelegate);
+        } else {
+            // New delegation, increment the counter
+            counter[id] += 1;
         }
 
         emit SetDelegate(msg.sender, id, delegate);
@@ -60,7 +60,7 @@ contract DelegateRegistry {
 
         // update delegation mapping
         delegation[msg.sender][id] = address(0);
-        counter[currentDelegate][id] -= 1;
+        counter[id] -= 1;
         _reverseDelegation[currentDelegate][id].remove(msg.sender);
 
         emit ClearDelegate(msg.sender, id, currentDelegate);

--- a/src/DelegateRegistry.sol
+++ b/src/DelegateRegistry.sol
@@ -11,6 +11,11 @@ contract DelegateRegistry {
     mapping(address delegator => mapping(bytes32 id => address delegate)) public delegation;
 
     // The first key is the delegate and the second key an id.
+    // The value is the number of delegations to this delegate for this id.
+    // This is used by Herodotus.
+    mapping(address delegate => mapping(bytes32 id => uint256 count)) public counter;
+
+    // The first key is the delegate and the second key an id.
     // The value is a set of delegators
     // This is used to build up a reverse lookup of delegators for a specific delegate.
     // The reverse lookup is not used in the contract itself, but it is useful for external
@@ -35,9 +40,11 @@ contract DelegateRegistry {
         // Update delegation mapping
         delegation[msg.sender][id] = delegate;
         _reverseDelegation[delegate][id].add(msg.sender);
+        counter[delegate][id] += 1;
 
         if (currentDelegate != address(0)) {
             _reverseDelegation[currentDelegate][id].remove(msg.sender);
+            counter[currentDelegate][id] -= 1;
             emit ClearDelegate(msg.sender, id, currentDelegate);
         }
 
@@ -53,6 +60,7 @@ contract DelegateRegistry {
 
         // update delegation mapping
         delegation[msg.sender][id] = address(0);
+        counter[currentDelegate][id] -= 1;
         _reverseDelegation[currentDelegate][id].remove(msg.sender);
 
         emit ClearDelegate(msg.sender, id, currentDelegate);

--- a/src/DelegateRegistry.sol
+++ b/src/DelegateRegistry.sol
@@ -68,7 +68,7 @@ contract DelegateRegistry {
     function isDelegator(address delegate, bytes32 id, address delegator) external view returns (bool) {
         return _reverseDelegation[delegate][id].contains(delegator);
     }
-    
+
     /**
      * @notice Get the number of delegators for a specific delegate and ID
      * @param delegate The delegate address
@@ -78,7 +78,7 @@ contract DelegateRegistry {
     function delegatorCount(address delegate, bytes32 id) external view returns (uint256) {
         return _reverseDelegation[delegate][id].length();
     }
-    
+
     /**
      * @notice Get a delegator by index for a specific delegate and ID
      * @param delegate The delegate address
@@ -99,11 +99,11 @@ contract DelegateRegistry {
     function getDelegators(address delegate, bytes32 id) external view returns (address[] memory) {
         uint256 count = _reverseDelegation[delegate][id].length();
         address[] memory result = new address[](count);
-        
+
         for (uint256 i = 0; i < count; i++) {
             result[i] = _reverseDelegation[delegate][id].at(i);
         }
-        
+
         return result;
     }
 }

--- a/test/DelegateRegistry.t.sol
+++ b/test/DelegateRegistry.t.sol
@@ -18,6 +18,7 @@ contract CounterTest is Test {
         registry.setDelegate(id, delegate);
 
         assertEq(registry.delegatorCount(delegate, id), 1);
+        assertEq(registry.counter(delegate, id), 1);
         address[] memory delegators = registry.getDelegators(delegate, id);
         assertEq(delegators.length, 1);
         assertEq(delegators[0], address(this));
@@ -31,6 +32,7 @@ contract CounterTest is Test {
         registry.setDelegate(id, delegate);
 
         assertEq(registry.delegatorCount(delegate, id), 2);
+        assertEq(registry.counter(delegate, id), 2);
         assertEq(true, registry.isDelegator(delegate, id, address(this)));
         assertEq(true, registry.isDelegator(delegate, id, address(123)));
     }
@@ -45,9 +47,11 @@ contract CounterTest is Test {
         assertEq(true, registry.isDelegator(delegate, id, address(123)));
 
         assertEq(registry.delegatorCount(delegate, id), 2);
+        assertEq(registry.counter(delegate, id), 2);
 
         registry.clearDelegate(id);
         assertEq(registry.delegatorCount(delegate, id), 1);
+        assertEq(registry.counter(delegate, id), 1);
         assertEq(false, registry.isDelegator(delegate, id, address(this)));
 
         vm.prank(address(123));

--- a/test/DelegateRegistry.t.sol
+++ b/test/DelegateRegistry.t.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.8.29;
 import {Test, console} from "forge-std/Test.sol";
 import {DelegateRegistry} from "../src/DelegateRegistry.sol";
 
-contract CounterTest is Test {
+contract DelegateTest is Test {
     DelegateRegistry public registry;
     bytes32 id = bytes32(keccak256(abi.encode("test")));
     address delegate = address(0x111);
@@ -18,7 +18,7 @@ contract CounterTest is Test {
         registry.setDelegate(id, delegate);
 
         assertEq(registry.delegatorCount(delegate, id), 1);
-        assertEq(registry.counter(delegate, id), 1);
+        assertEq(registry.counter(id), 1);
         address[] memory delegators = registry.getDelegators(delegate, id);
         assertEq(delegators.length, 1);
         assertEq(delegators[0], address(this));
@@ -32,7 +32,7 @@ contract CounterTest is Test {
         registry.setDelegate(id, delegate);
 
         assertEq(registry.delegatorCount(delegate, id), 2);
-        assertEq(registry.counter(delegate, id), 2);
+        assertEq(registry.counter(id), 2);
         assertEq(true, registry.isDelegator(delegate, id, address(this)));
         assertEq(true, registry.isDelegator(delegate, id, address(123)));
     }
@@ -42,22 +42,30 @@ contract CounterTest is Test {
         registry.setDelegate(id, delegate);
         assertEq(true, registry.isDelegator(delegate, id, address(this)));
 
-        vm.prank(address(123));
-        registry.setDelegate(id, delegate);
-        assertEq(true, registry.isDelegator(delegate, id, address(123)));
+        address delegate2 = address(0x222);
+        registry.setDelegate(id, delegate2);
+        assertEq(false, registry.isDelegator(delegate, id, address(this)));
+        assertEq(true, registry.isDelegator(delegate2, id, address(this)));
+        assertEq(registry.counter(id), 1);
 
-        assertEq(registry.delegatorCount(delegate, id), 2);
-        assertEq(registry.counter(delegate, id), 2);
+        vm.prank(address(0x123));
+        registry.setDelegate(id, delegate);
+        assertEq(true, registry.isDelegator(delegate, id, address(0x123)));
+
+        assertEq(registry.delegatorCount(delegate, id), 1);
+        assertEq(registry.delegatorCount(delegate2, id), 1);
+        assertEq(registry.counter(id), 2);
 
         registry.clearDelegate(id);
         assertEq(registry.delegatorCount(delegate, id), 1);
-        assertEq(registry.counter(delegate, id), 1);
+        assertEq(registry.delegatorCount(delegate2, id), 0);
+        assertEq(registry.counter(id), 1);
         assertEq(false, registry.isDelegator(delegate, id, address(this)));
 
-        vm.prank(address(123));
+        vm.prank(address(0x123));
         registry.clearDelegate(id);
         assertEq(registry.delegatorCount(delegate, id), 0);
-        assertEq(false, registry.isDelegator(delegate, id, address(123)));
+        assertEq(false, registry.isDelegator(delegate, id, address(0x123)));
     }
 
     function test_ClearNullDelegate() public {

--- a/test/DelegateRegistry.t.sol
+++ b/test/DelegateRegistry.t.sol
@@ -7,44 +7,53 @@ import {DelegateRegistry} from "../src/DelegateRegistry.sol";
 contract CounterTest is Test {
     DelegateRegistry public registry;
     bytes32 id = bytes32(keccak256(abi.encode("test")));
-    address delegator = address(0x111);
+    address delegate = address(0x111);
 
     function setUp() public {
         registry = new DelegateRegistry();
     }
 
     function test_Delegate() public {
-        assertEq(registry.counter(delegator, id), 0);
-        registry.setDelegate(id, delegator);
+        assertEq(registry.delegatorCount(delegate, id), 0);
+        registry.setDelegate(id, delegate);
 
-        assertEq(registry.counter(delegator, id), 1);
+        assertEq(registry.delegatorCount(delegate, id), 1);
+        address[] memory delegators = registry.getDelegators(delegate, id);
+        assertEq(delegators.length, 1);
+        assertEq(delegators[0], address(this));
     }
 
     function test_DelegateTwo() public {
-        assertEq(registry.counter(delegator, id), 0);
-        registry.setDelegate(id, delegator);
+        assertEq(registry.delegatorCount(delegate, id), 0);
+        registry.setDelegate(id, delegate);
 
         vm.prank(address(123));
-        registry.setDelegate(id, delegator);
+        registry.setDelegate(id, delegate);
 
-        assertEq(registry.counter(delegator, id), 2);
+        assertEq(registry.delegatorCount(delegate, id), 2);
+        assertEq(true, registry.isDelegator(delegate, id, address(this)));
+        assertEq(true, registry.isDelegator(delegate, id, address(123)));
     }
 
     function test_ClearDelegate() public {
-        assertEq(registry.counter(delegator, id), 0);
-        registry.setDelegate(id, delegator);
+        assertEq(registry.delegatorCount(delegate, id), 0);
+        registry.setDelegate(id, delegate);
+        assertEq(true, registry.isDelegator(delegate, id, address(this)));
 
         vm.prank(address(123));
-        registry.setDelegate(id, delegator);
+        registry.setDelegate(id, delegate);
+        assertEq(true, registry.isDelegator(delegate, id, address(123)));
 
-        assertEq(registry.counter(delegator, id), 2);
+        assertEq(registry.delegatorCount(delegate, id), 2);
 
         registry.clearDelegate(id);
-        assertEq(registry.counter(delegator, id), 1);
+        assertEq(registry.delegatorCount(delegate, id), 1);
+        assertEq(false, registry.isDelegator(delegate, id, address(this)));
 
         vm.prank(address(123));
         registry.clearDelegate(id);
-        assertEq(registry.counter(delegator, id), 0);
+        assertEq(registry.delegatorCount(delegate, id), 0);
+        assertEq(false, registry.isDelegator(delegate, id, address(123)));
     }
 
     function test_ClearNullDelegate() public {


### PR DESCRIPTION
Adds a way to track the reverse delegates directly on the contract (i.e., get a list of delegators who delegates to the user).

The function is `getDelegators(address delegate, bytes32 id)`
We remove the `counter` public function and replace it by `delegatorCount(address delegate, bytes32 id)` (instead of duplicating the code).
We also add a utility function `isDelegator(address delegate, bytes32 id, address delegator)` to to quickly check if a user has delegated to that delegate or not.

(`delegatorAt` is added here just in case it's used later on)

We are using [EnumerableSet](https://docs.openzeppelin.com/contracts/5.x/api/utils#EnumerableSet) from OZ to make all these operations in O(1).